### PR TITLE
Yumprogress obj has no attrib package

### DIFF
--- a/pakrat/__init__.py
+++ b/pakrat/__init__.py
@@ -78,11 +78,11 @@ def sync(basedir=None, objrepos=[], repodirs=[], repofiles=[],
         # nonlocal keyword).
         while not queue.empty():
             e = queue.get()
-            if 'action' not in e:
+            if not e.has_key('action'):
                 continue
-            if e['action'] == 'repo_init' and 'value' in e:
+            if e['action'] == 'repo_init' and e.has_key('value'):
                 prog.update(e['repo_id'], set_total=e['value'])
-            elif e['action'] == 'download_end' and 'value' in e:
+            elif e['action'] == 'download_end' and e.has_key('value'):
                 prog.update(e['repo_id'], pkgs_downloaded=e['value'])
             elif e['action'] == 'repo_metadata':
                 prog.update(e['repo_id'], repo_metadata=e['value'])

--- a/pakrat/__init__.py
+++ b/pakrat/__init__.py
@@ -3,8 +3,6 @@ import sys
 import multiprocessing
 import signal
 import urlparse
-
-
 from pakrat import util, log, repo, repos, progress
 
 __version__ = '0.3.3'
@@ -19,7 +17,6 @@ def sync(basedir=None, objrepos=[], repodirs=[], repofiles=[],
     on to threads for doing the actual syncing. One thread is created per
     repository to alleviate the impact of slow mirrors on faster ones.
     """
-    util.validate_repos(objrepos)
     util.validate_repofiles(repofiles)
     util.validate_repodirs(repodirs)
 
@@ -41,6 +38,9 @@ def sync(basedir=None, objrepos=[], repodirs=[], repofiles=[],
     manager = multiprocessing.Manager()
     queue = manager.Queue()
     processes = []
+
+    util.validate_repos(objrepos)
+
     for objrepo in objrepos:
         prog.update(objrepo.id)  # Add the repo to the progress object
         yumcallback = progress.YumProgress(objrepo.id, queue, callback)

--- a/pakrat/progress.py
+++ b/pakrat/progress.py
@@ -121,7 +121,7 @@ class Progress(object):
         This makes calls to the other methods of this class to create a
         formatted string, which makes nice columns.
         """
-        if 'error' not in self.repos[repo_id]:
+        if self.repos[repo_id].has_key('error'):
             packages = '     error'
             percent = ''
             metadata = ''

--- a/pakrat/repo.py
+++ b/pakrat/repo.py
@@ -129,11 +129,13 @@ def sync(repo, dest, version, delete=False, combined=False, yumcallback=None,
         packages_dir = util.get_packages_dir(dest_dir)
     try:
         yb = util.get_yum()
+        repo.enable()
         repo = set_path(repo, packages_dir)
         if yumcallback:
             repo.setCallback(yumcallback)
         yb.repos.add(repo)
         yb.repos.enableRepo(repo.id)
+        yb.doSackSetup(thisrepo=repo.id)
         with suppress():
             # showdups allows us to get multiple versions of the same package.
             ygh = yb.doPackageLists(showdups=True)

--- a/pakrat/repos.py
+++ b/pakrat/repos.py
@@ -15,7 +15,6 @@ def from_file(path):
     yb.getReposFromConfigFile(path)
     repos = []
     for repo in yb.repos.listEnabled():
-        yb._getSacks(thisrepo=repo.id)
         if repo.isEnabled():
             log.info('Added repo %s from file %s' % (repo.id, path))
             repos.append(repo)

--- a/pakrat/repos.py
+++ b/pakrat/repos.py
@@ -11,11 +11,11 @@ def from_file(path):
     if not os.path.exists(path):
         raise Exception('No such file or directory: %s' % path)
     yb = util.get_yum()
+    yb.repos.disableRepo('*')
     yb.getReposFromConfigFile(path)
-    for repo in yb.repos.findRepos('*'):
-        yb.doSackSetup(thisrepo=repo.getAttribute('name'))
     repos = []
-    for repo in yb.repos.findRepos('*'):
+    for repo in yb.repos.listEnabled():
+        yb._getSacks(thisrepo=repo.id)
         if repo.isEnabled():
             log.info('Added repo %s from file %s' % (repo.id, path))
             repos.append(repo)


### PR DESCRIPTION
finally got this functional after a significant amount of fighting with the pakrat codebase as well as a VERY POORLY documented Yum API. The code changes enable it to mirror and version a repo using a repo config. The CLI output for the repofiles option is 0 for the totals, but it no longer errors and thus actually sets up the repository correctly.

https://github.com/abtreece/pakrat/issues/2